### PR TITLE
Fixing the timer glitch

### DIFF
--- a/whathecolor.js
+++ b/whathecolor.js
@@ -81,7 +81,6 @@ function pad(number, zeros) {
 var t_; // Variable to hold timer
 
 var _ = self.Whathecolor = {
-
 	solved: false,
 	
 	play: function () {
@@ -91,10 +90,9 @@ var _ = self.Whathecolor = {
 		
 		solution.style.background = color;
 		
-		if(t != null)
-			t.stop()
-		t = new Timer(timer);
-		t.start();
+		t_ && t_.stop()
+		t_ = new Timer(timer);
+		t_.start();
 		
 		// Clean up from previous attempts
 		proximity.textContent = '0%';


### PR DESCRIPTION
After 3 minutes if we press the 'Skip' button, there is a glitch in the timer. The previous times was not killed and a new timer is created. So there are two timer which tries to modify the UI component that displays the time. 

This PR is to fix(#1) the glitch by killing the previously created timer. 
